### PR TITLE
Improve

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ MIMIR_VERSION ?= 2.6.0
 default: testacc
 
 # Run acceptance tests
-.PHONY: testacc
+.PHONY: testacc docs
 testacc: compose-up
 	TF_ACC=1 MIMIRTOOL_ADDRESS=http://localhost:8080 go test ./... -v $(TESTARGS) -timeout 120m
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,6 @@ provider "mimirtool" {
 - `auth_token` (String, Sensitive) Authentication token for bearer token or JWT auth when contacting Grafana Mimir. May alternatively be set via the `MIMIRTOOL_AUTH_TOKEN` or `MIMIR_AUTH_TOKEN` environment variable.
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification. May alternatively be set via the `MIMIRTOOL_INSECURE_SKIP_VERIFY` or `MIMIR_INSECURE_SKIP_VERIFY` environment variable.
 - `prometheus_http_prefix` (String) Path prefix to use for rules. May alternatively be set via the `MIMIRTOOL_PROMETHEUS_HTTP_PREFIX` or `MIMIR_PROMETHEUS_HTTP_PREFIX` environment variable.
-- `store_rules_sha256` (Boolean) Set to true if you want to save only the sha256sum instead of namespace's groups rules definition in the tfstate. May alternatively be set via the `MIMIRTOOL_STORE_RULES_SHA256` or `MIMIR_STORE_RULES_SHA256` environment variable.
 - `tenant_id` (String) Tenant ID to use when contacting Grafana Mimir. May alternatively be set via the `MIMIRTOOL_TENANT_ID` or `MIMIR_TENANT_ID` environment variable.
 - `tls_ca_path` (String) Certificate CA bundle to use to verify the MIMIR server's certificate. May alternatively be set via the `MIMIRTOOL_TLS_CA_PATH` or `MIMIR_TLS_CA_PATH` environment variable.
 - `tls_cert_path` (String) Client TLS certificate file to use to authenticate to the MIMIR server. May alternatively be set via the `MIMIRTOOL_TLS_CERT_PATH` or `MIMIR_TLS_CERT_PATH` environment variable.

--- a/mimirtool/provider.go
+++ b/mimirtool/provider.go
@@ -11,10 +11,6 @@ import (
 	mimirtool "github.com/grafana/mimir/pkg/mimirtool/client"
 )
 
-var (
-	storeRulesSHA256 bool
-)
-
 func init() {
 	// Set descriptions to support markdown syntax, this will be used in document generation
 	// and the language server.
@@ -108,12 +104,6 @@ func New(version string) func() *schema.Provider {
 					DefaultFunc: schema.MultiEnvDefaultFunc([]string{"MIMIRTOOL_ALERTMANAGER_HTTP_PREFIX", "MIMIR_ALERTMANAGER_HTTP_PREFIX"}, "/alertmanager"),
 					Description: "Path prefix to use for alertmanager. May alternatively be set via the `MIMIRTOOL_ALERTMANAGER_HTTP_PREFIX` or `MIMIR_ALERTMANAGER_HTTP_PREFIX` environment variable.",
 				},
-				"store_rules_sha256": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					DefaultFunc: schema.MultiEnvDefaultFunc([]string{"MIMIRTOOL_STORE_RULES_SHA256", "MIMIR_STORE_RULES_SHA256"}, false),
-					Description: "Set to true if you want to save only the sha256sum instead of namespace's groups rules definition in the tfstate. May alternatively be set via the `MIMIRTOOL_STORE_RULES_SHA256` or `MIMIR_STORE_RULES_SHA256` environment variable.",
-				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{},
 			ResourcesMap: map[string]*schema.Resource{
@@ -142,8 +132,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
-
-		storeRulesSHA256 = d.Get("store_rules_sha256").(bool)
 		return c, diags
 	}
 }

--- a/mimirtool/provider_test.go
+++ b/mimirtool/provider_test.go
@@ -2,22 +2,12 @@ package mimirtool
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-func getSetEnv(key, fallback string) string {
-	value, exists := os.LookupEnv(key)
-	if !exists {
-		value = fallback
-		os.Setenv(key, fallback)
-	}
-	return value
-}
 
 // testAccProviderFactories is a static map containing only the main provider instance
 var testAccProviderFactories map[string]func() (*schema.Provider, error)

--- a/mimirtool/resource_ruler_namespace.go
+++ b/mimirtool/resource_ruler_namespace.go
@@ -2,7 +2,6 @@ package mimirtool
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 
 	"github.com/grafana/mimir/pkg/mimirtool/rules"
@@ -212,10 +211,6 @@ func normalizeNamespaceYAML(config any) string {
 	ruleNamespace.LintExpressions(rules.MimirBackend)
 
 	namespaceBytes, _ := yaml.Marshal(ruleNamespace.Groups)
-	if storeRulesSHA256 {
-		configHash := sha256.Sum256(namespaceBytes)
-		return fmt.Sprintf("%x", configHash[:])
-	}
 	return string(namespaceBytes)
 }
 

--- a/mimirtool/resource_ruler_namespace_test.go
+++ b/mimirtool/resource_ruler_namespace_test.go
@@ -1,8 +1,6 @@
 package mimirtool
 
 import (
-	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -10,71 +8,54 @@ import (
 )
 
 func TestAccResourceNamespace(t *testing.T) {
-	for _, useSHA256 := range []bool{false, true} {
-		os.Setenv("MIMIR_STORE_RULES_SHA256", fmt.Sprintf("%t", useSHA256))
-		defer os.Unsetenv("MIMIR_STORE_RULES_SHA256")
-
-		expectedInitialConfig := testAccResourceNamespaceYaml
-		expectedInitialConfigAfterUpdate := testAccResourceNamespaceYamlAfterUpdate
-		if useSHA256 {
-			expectedInitialConfig = "a90a22389a8e736469aa2c70145ca4d3481c5f6565423fef484f140541eec113"
-			expectedInitialConfigAfterUpdate = "fce4306cdc615aeb3c04385ff7b565cbbe77453758894f898e4651576510f883"
-		}
-		resource.UnitTest(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
-			ProviderFactories: testAccProviderFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: testAccResourceNamespace,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "namespace", "demo"),
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "config_yaml", expectedInitialConfig),
-					),
-				},
-				{
-					Config: testAccResourceNamespaceAfterUpdate,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "namespace", "demo"),
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "config_yaml", expectedInitialConfigAfterUpdate),
-					),
-				},
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNamespace,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "namespace", "demo"),
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "config_yaml", testAccResourceNamespaceYaml),
+				),
 			},
-		})
-	}
+			{
+				Config: testAccResourceNamespaceAfterUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "namespace", "demo"),
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "config_yaml", testAccResourceNamespaceYamlAfterUpdate),
+				),
+			},
+		},
+	})
 }
 
 func TestAccResourceNamespaceDiffSuppress(t *testing.T) {
-	for _, useSHA256 := range []bool{false, true} {
-		os.Setenv("MIMIR_STORE_RULES_SHA256", fmt.Sprintf("%t", useSHA256))
-		defer os.Unsetenv("MIMIR_STORE_RULES_SHA256")
 
-		var expected string
-		if !useSHA256 {
-			expected = testAccResourceNamespaceYamlWhitespace
-		} else {
-			expected = "f9a92a1e50895f6c0e626a2c8b0a8c4f6c1211e9d1089e73163b08c366a8dfc4"
-		}
-
-		resource.UnitTest(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
-			ProviderFactories: testAccProviderFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: testAccResourceNamespaceWhitespaceDiff,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "namespace", "demo"),
-						resource.TestCheckResourceAttr(
-							"mimirtool_ruler_namespace.demo", "config_yaml", expected),
-					),
-				},
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNamespaceWhitespaceDiff,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "namespace", "demo"),
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "config_yaml", testAccResourceNamespaceYamlWhitespace),
+				),
 			},
-		})
-	}
+		},
+	})
+}
+
+			},
+		},
+	})
 }
 
 func TestAccResourceNamespaceCheckRules(t *testing.T) {

--- a/mimirtool/testdata/rules-quoting.yaml
+++ b/mimirtool/testdata/rules-quoting.yaml
@@ -1,0 +1,25 @@
+namespace: rules-quoting
+groups:
+    - name: NodeExporter
+      rules:
+        - alert: HostDiskWillFillIn24Hours
+          expr: '(node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10 and ON (instance, device, mountpoint) predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs"}[1h], 24 * 3600) < 0 and on (instance, device, mountpoint) node_filesystem_readonly == 0'
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            description: |-
+                Filesystem is predicted to run out of space within the next 24 hours at current write rate
+                  VALUE = {{ $value }}
+                  LABELS = {{ $labels }}
+            summary: Host disk will fill in 24 hours (instance {{ $labels.instance }})
+        - alert: HostHighCpuLoad
+          expr: '100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[2m])) * 100) > 80'
+          labels:
+            severity: warning
+          annotations:
+            description: |-
+                CPU load is > 80%
+                  VALUE = {{ $value }}
+                  LABELS = {{ $labels }}
+            summary: Host high CPU load (instance {{ $labels.instance }})


### PR DESCRIPTION
This PR aims to add  a test case when rules are defined with quote.
It also include the removal of [store_rules_sha256](https://github.com/ovh/terraform-provider-mimirtool/commit/54710866bb82af9e13f7d74f2df152513cb83765) which we have found hard to use efficiently as the diff is unreadable.