### PR TITLE
feat: allow skipping recording rule checks entirely

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,14 @@ jobs:
         # regularly on HashiCorp product pages for each HashiCorp product.
         # See: https://support.hashicorp.com/hc/en-us/articles/360021185113
         terraform:
-          - '1.3.*'
-          - '1.4.*'
+          - '1.5.*'
+          - '1.6.*'
         # We will support the 3 last minor versions as Grafana honor 2 versions
         # before dropping a deprecated flag
         mimir:
-          - '2.5.0'
-          - '2.6.0'
+          - '2.11.0'
+          - '2.12.0'
+          - '2.13.0'
 
     steps:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,11 +11,11 @@ build:
 	go build -o dist/
 
 compose-up: compose-down
-	MIMIR_VERSION=$(MIMIR_VERSION) docker-compose -f ./docker-compose.yml up -d
+	MIMIR_VERSION=$(MIMIR_VERSION) docker compose -f ./docker-compose.yml up -d
 	curl -s --retry 12 -f --retry-all-errors --retry-delay 10 http://localhost:8080/ready
 
 compose-down:
-	docker-compose -f ./docker-compose.yml stop
+	docker compose -f ./docker-compose.yml stop
 
 docs:
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/docs/resources/ruler_namespace.md
+++ b/docs/resources/ruler_namespace.md
@@ -39,6 +39,7 @@ EOT
 
 ### Optional
 
+- `recording_rule_check` (Boolean) Controls whether to run recording rule checks entirely.
 - `strict_recording_rule_check` (Boolean) Fails rules checks that do not match best practices exactly. See: https://prometheus.io/docs/practices/rules/
 
 ### Read-Only

--- a/mimirtool/resource_ruler_namespace.go
+++ b/mimirtool/resource_ruler_namespace.go
@@ -191,7 +191,7 @@ func rulerNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	for _, name := range currentGroupsNames {
 		if !slices.Contains(nsGroupNames, name) {
 			errRaw := client.DeleteRuleGroup(ctx, namespace, name)
-			if err != nil {
+			if errRaw != nil {
 				return diag.FromErr(errRaw)
 			}
 		}

--- a/mimirtool/resource_ruler_namespace.go
+++ b/mimirtool/resource_ruler_namespace.go
@@ -48,6 +48,12 @@ func resourceRulerNamespace() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"recording_rule_check": {
+				Description: "Controls whether to run recording rule checks entirely.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
 		},
 	}
 }
@@ -94,15 +100,18 @@ func rulerNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	namespace := d.Get("namespace").(string)
 	ruleGroup := d.Get("config_yaml").(string)
 	strictRecordingRuleCheck := d.Get("strict_recording_rule_check").(bool)
+	recordingRuleCheck := d.Get("recording_rule_check").(bool)
 
 	ruleNamespace, err := getRuleNamespaceFromYAML(ctx, ruleGroup)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = checkRecordingRules(ruleNamespace, strictRecordingRuleCheck)
-	if err != nil {
-		return diag.FromErr(err)
+	if recordingRuleCheck {
+		err = checkRecordingRules(ruleNamespace, strictRecordingRuleCheck)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	for _, group := range ruleNamespace.Groups {
@@ -144,6 +153,7 @@ func rulerNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	namespace := d.Get("namespace").(string)
 	ruleGroup := d.Get("config_yaml").(string)
 	strictRecordingRuleCheck := d.Get("strict_recording_rule_check").(bool)
+	recordingRuleCheck := d.Get("recording_rule_check").(bool)
 
 	errDiag := rulerNamespaceCreate(ctx, d, meta)
 	if errDiag != nil {
@@ -155,9 +165,11 @@ func rulerNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = checkRecordingRules(ruleNamespace, strictRecordingRuleCheck)
-	if err != nil {
-		return diag.FromErr(err)
+	if recordingRuleCheck {
+		err = checkRecordingRules(ruleNamespace, strictRecordingRuleCheck)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	var nsGroupNames []string

--- a/mimirtool/resource_ruler_namespace_test.go
+++ b/mimirtool/resource_ruler_namespace_test.go
@@ -105,6 +105,23 @@ func TestAccResourceNamespaceCheckRules(t *testing.T) {
 			},
 		},
 	})
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNamespaceNoCheck,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "namespace", "demo"),
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "recording_rule_check", "false"),
+					resource.TestCheckResourceAttr(
+						"mimirtool_ruler_namespace.demo", "config_yaml", testAccResourceNamespaceNoCheckExpected),
+				),
+			},
+		},
+	})
 }
 
 func TestAccResourceNamespaceParseRules(t *testing.T) {
@@ -189,6 +206,20 @@ resource "mimirtool_ruler_namespace" "demo" {
   }
 `
 
+const testAccResourceNamespaceNoCheck = `
+resource "mimirtool_ruler_namespace" "demo" {
+	namespace = "demo"
+	config_yaml = file("testdata/rules-fails-check.yaml")
+	recording_rule_check = false
+  }
+`
+
+const testAccResourceNamespaceNoCheckExpected = `groups:
+    - name: mimir_api_1
+      rules:
+        - record: cluster_job_cortex_request_duration_seconds_99quantile
+          expr: histogram_quantile(0.99, sum by (le, cluster, job) (rate(cortex_request_duration_seconds_bucket[1m])))
+`
 const testAccResourceNamespaceParseError = `
 resource "mimirtool_ruler_namespace" "demo" {
 	namespace = "demo"


### PR DESCRIPTION
- **feat: update tf/mimir test versions.**
- **feat: allow skipping recording rule checks entirely**
- **fix: impossible comparison**
- **fix: switch to calling 'docker compose'**

I'm adding this PR to allow overriding the requirement of at least a single `:` in a recording rule. Some rules are not aggregations or come from 3rd parties, for instance projects like [https://sloth.dev/](https://sloth.dev/). 

This PR also includes minor bugfixes as well as updating the terraform/mimir test matrices, which I'm happy to submit separate PRs for.  