### PR TITLE
Import ruler namespace ressource using namespace name instead of id

### DIFF
--- a/docs/resources/ruler_namespace.md
+++ b/docs/resources/ruler_namespace.md
@@ -46,4 +46,10 @@ EOT
 
 - `id` (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import mimirtool_ruler_namespace.demo demo
+```

--- a/examples/resources/mimirtool_ruler_namespace/import.sh
+++ b/examples/resources/mimirtool_ruler_namespace/import.sh
@@ -1,0 +1,1 @@
+terraform import mimirtool_ruler_namespace.demo demo

--- a/mimirtool/resource_ruler_namespace.go
+++ b/mimirtool/resource_ruler_namespace.go
@@ -25,7 +25,7 @@ func resourceRulerNamespace() *schema.Resource {
 		UpdateContext: rulerNamespaceUpdate,
 		DeleteContext: rulerNamespaceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: rulerNamespaceImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -211,6 +211,16 @@ func rulerNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId("")
 	return diags
+}
+
+func rulerNamespaceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	namespace := d.Id()
+	d.Set("namespace", namespace)
+	d.SetId(hash(namespace))
+
+	results := make([]*schema.ResourceData, 1)
+	results[0] = d
+	return results, nil
 }
 
 // Borrowed from https://github.com/grafana/terraform-provider-grafana/blob/master/grafana/resource_dashboard.go

--- a/mimirtool/resource_ruler_namespace_test.go
+++ b/mimirtool/resource_ruler_namespace_test.go
@@ -30,6 +30,14 @@ func TestAccResourceNamespace(t *testing.T) {
 						"mimirtool_ruler_namespace.demo", "config_yaml", testAccResourceNamespaceYamlAfterUpdate),
 				),
 			},
+			{
+				ResourceName:      "mimirtool_ruler_namespace.demo",
+				ImportStateId:     "demo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// These fields can't be retrieved from mimir ruler
+				ImportStateVerifyIgnore: []string{"recording_rule_check", "strict_recording_rule_check"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
We can't query a ruler namespace using id